### PR TITLE
Add link to encoding example

### DIFF
--- a/methods/personal_sign.json
+++ b/methods/personal_sign.json
@@ -7,7 +7,7 @@
     {
       "name": "Challenge",
       "required": true,
-      "description": "A hex-encoded UTF-8 string to present to the user. For example, '0x${Buffer.from(exampleMessage, 'utf8').toString('hex')}'",
+      "description": "A hex-encoded UTF-8 string to present to the user. You can see how to encode a string like this in the module [browser-string-hexer](https://github.com/danfinlay/browser-string-hexer).",
       "schema": {
         "type": "string",
         "pattern": "^0x[a-fA-F\\d]+$"

--- a/methods/personal_sign.json
+++ b/methods/personal_sign.json
@@ -1,7 +1,7 @@
 {
   "name": "personal_sign",
   "summary": "Presents a plain text signature challenge to the user.",
-  "description": "Presents a plain text signature challenge to the user and returns the signed response. This method is equivalent to eth_sign on some other wallets, and prepends a safe prefix to the signed message to prevent the challenge tricking users into signing a financial transaction.",
+  "description": "Presents a plain text signature challenge to the user and returns the signed response. This method is equivalent to eth_sign on some other wallets, and prepends a safe prefix to the signed message to prevent the challenge tricking users into signing a financial transaction. This method requires that the user has granted permission to interact with their account first, so make sure to call `eth_requestAccounts` first.",
   "deprecated": false,
   "params": [
     {


### PR DESCRIPTION
Improving `personal_sign` documentation in two ways:
- Include link to minimal encoding example
- Document the need to connect the account first