### PR TITLE
Add permission method for wallet_getLocale

### DIFF
--- a/metamask-openrpc.json
+++ b/metamask-openrpc.json
@@ -15,7 +15,7 @@
             "$ref": "./methods/wallet_requestPermissions.json"
         },
         {
-            "$ref": "./methods/wallet_getLanguage.json"
+            "$ref": "./methods/wallet_getLocale.json"
         },
         {
             "$ref": "./methods/wallet_getPermissions.json"

--- a/metamask-openrpc.json
+++ b/metamask-openrpc.json
@@ -15,6 +15,9 @@
             "$ref": "./methods/wallet_requestPermissions.json"
         },
         {
+            "$ref": "./methods/wallet_getLanguage.json"
+        },
+        {
             "$ref": "./methods/wallet_getPermissions.json"
         },
         {

--- a/methods/wallet_getLanguage.json
+++ b/methods/wallet_getLanguage.json
@@ -1,0 +1,17 @@
+{
+  "tags": [
+    {
+      "$ref": "../tags/Metamask.json"
+    }
+  ],
+  "name": "wallet_getLanguage",
+  "summary": "Get language",
+  "description": "Get the user's current language.",
+  "params": [],
+  "result": {
+    "name": "LanguageResult",
+    "schema": {
+      "type": "string"
+    }
+  }
+}

--- a/methods/wallet_getLocale.json
+++ b/methods/wallet_getLocale.json
@@ -4,12 +4,12 @@
       "$ref": "../tags/Metamask.json"
     }
   ],
-  "name": "wallet_getLanguage",
-  "summary": "Get language",
-  "description": "Get the user's current language.",
+  "name": "wallet_getLocale",
+  "summary": "Get locale",
+  "description": "Get the user's current language locale.",
   "params": [],
   "result": {
-    "name": "LanguageResult",
+    "name": "LocaleResult",
     "schema": {
       "type": "string"
     }


### PR DESCRIPTION
I added a simple permission for `wallet_getLanguage`. I wasn't sure how detailed and specific we should make this permission but I see a possible improvement: converting `LanguageResult` to a enum-like data type where we specify exactly what languages would be returned instead of a returning it as a general "string" type.