### PR TITLE
Changed wallet_watchAsset description to 11 characters

### DIFF
--- a/methods/wallet_watchAsset.json
+++ b/methods/wallet_watchAsset.json
@@ -29,7 +29,7 @@
             "type": "string"
           },
           "symbol": {
-            "description": " A ticker symbol or shorthand, up to 5 characters",
+            "description": " A ticker symbol or shorthand, up to 11 characters",
             "type": "string"
           },
           "decimals": {

--- a/methods/wallet_watchAsset.json
+++ b/methods/wallet_watchAsset.json
@@ -30,6 +30,8 @@
           },
           "symbol": {
             "description": " A ticker symbol or shorthand, up to 11 characters",
+            "minLength": 2,
+            "maxLength": 11,
             "type": "string"
           },
           "decimals": {

--- a/methods/wallet_watchAsset.json
+++ b/methods/wallet_watchAsset.json
@@ -32,8 +32,6 @@
             "description": " A ticker symbol or shorthand, up to 11 characters",
             "minLength": 2,
             "maxLength": 11,
-            "minLength": 2,
-            "maxLength": 11,
             "type": "string"
           },
           "decimals": {

--- a/methods/wallet_watchAsset.json
+++ b/methods/wallet_watchAsset.json
@@ -32,6 +32,8 @@
             "description": " A ticker symbol or shorthand, up to 11 characters",
             "minLength": 2,
             "maxLength": 11,
+            "minLength": 2,
+            "maxLength": 11,
             "type": "string"
           },
           "decimals": {


### PR DESCRIPTION
wallet_watchAsset symbol takes 11 characters, updated the description to reflect that.

Fixes https://github.com/MetaMask/metamask-extension/issues/7567