### PR TITLE
Add eth_getPlumeSignature to API spec

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -421,6 +421,40 @@
           "$ref": "#/components/schemas/bytes"
         }
       }
+    },
+    {
+      "name": "eth_getPlumeSignature",
+      "tags": [
+        {
+          "$ref": "#/components/tags/Metamask"
+        }
+      ],
+      "summary": "Generates the plume signature and necessary proof signals.",
+      "description": "Requests that MetaMask generates the plume signature and necessary proof signals.",
+      "params": [
+        {
+          "name": "Message",
+          "required": true,
+          "description": "A message to generate ",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "Address",
+          "required": true,
+          "description": "The address of the requested signing account",
+          "schema": {
+            "$ref": "#/components/schemas/address"
+          }
+        }
+      ],
+      "result": {
+        "name": "PlumeResult",
+        "schema": {
+          "$ref": "#/components/schemas/PlumeResponse"
+        }
+      }
     }
   ],
   "components": {
@@ -532,6 +566,35 @@
         "type": "array",
         "items": {
           "$ref": "#/components/schemas/Permission"
+        }
+      },
+      "PlumeResponse": {
+        "type": "object",
+        "properties": {
+          "plume": {
+            "description": "The deterministic signature generated for the given message, also a public input to the proof.",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "s": {
+            "description": "Private input to the proof.",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "c": {
+            "description": "Private input to the proof.",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "gPowR": {
+            "description": "Private input to the proof.",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "hashMPKPowR": {
+            "description": "Optional private output to the proof.",
+            "$ref": "#/components/schemas/bytes"
+          },
+          "publicKey": {
+            "description": "Optional private output to the proof.",
+            "$ref": "#/components/schemas/bytes"
+          }
         }
       }
     },


### PR DESCRIPTION
Follow-up to https://github.com/MetaMask/eth-json-rpc-middleware/pull/198#issuecomment-1438947809 -- added API spec. Here's a preview on [Open RPC](https://playground.open-rpc.org/):

<img width="804" alt="Screenshot 2023-02-23 at 1 39 23 AM" src="https://user-images.githubusercontent.com/36896271/220870788-203f21c0-4f27-4062-b049-985ad924160a.png">

