### PR TITLE
Ignore `engine_` apis from ethereum execution APIs spec

### DIFF
--- a/merge-openrpc.js
+++ b/merge-openrpc.js
@@ -25,6 +25,7 @@ const unneeded = [
   /eth_signTransaction/,
   /eth_sign/,
   /debug_.*/,
+  /engine_.*/
 ];
 
 const filterExecutionAPIs = (openrpcDocument) => {


### PR DESCRIPTION
this prevents `engine_` apis from showing up in the playground:

`engine_` namespaces is only for communication between an Ethereum Node (like geth) and a beacon chain node.

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/364566/230115475-ced7858e-1fb4-444e-a05b-d1a06d799c90.png">
