### PR TITLE
update wallet_watchAsset description to acknowledge the divergence between EIP-747 and our implementation

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -324,7 +324,7 @@
         }
       ],
       "summary": "Tracks a token in MetaMask.",
-      "description": "Requests that the user track the specified token in MetaMask. Returns a boolean indicating if the token was successfully added. Once added, the token is indistinguishable from those added using legacy methods, such as a centralized registry. Introduced by [EIP-747](https://eips.ethereum.org/EIPS/eip-747).",
+      "description": "Requests that the user track the specified token in MetaMask. Returns a boolean indicating if the token was successfully added. Once added, the token is indistinguishable from those added using legacy methods, such as a centralized registry. Originally introduced by [EIP-747](https://eips.ethereum.org/EIPS/eip-747), however the current specification for EIP-747 has diverged from the implementation in MetaMask. The implementation in MetaMask, described below, matches the version of EIP-747 found here: https://github.com/ethereum/EIPs/blob/36102e0c82630e2654fd019f54914330d1c37f74/EIPS/eip-747.md",
       "paramStructure": "by-name",
       "params": [
         {


### PR DESCRIPTION
Adds comment in the the description of `wallet_watchAsset` to to acknowledge the divergence between EIP-747 - to which [changes have been made](https://github.com/ethereum/EIPs/commit/4cdc9bd9a242b2f8c05961f79e05266303260119) which we do not intend to adopt - and our implementation