### PR TITLE
Fix `wallet_addEthereumChain` request

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -1015,8 +1015,8 @@
         "required": [
           "chainId",
           "chainName",
-          "rpcUrls",
-          "nativeCurrency"
+          "nativeCurrency",
+          "rpcUrls"
         ],
         "properties": {
           "chainId": {
@@ -1048,7 +1048,9 @@
           "rpcUrls": {
             "description": "One or more URLs pointing to RPC endpoints that can be used to communicate with the chain. At least one item is required, and only the first item is used.",
             "type": "array",
+            "minItems": 1,
             "items": {
+              "format": "uri",
               "type": "string"
             }
           }

--- a/openrpc.json
+++ b/openrpc.json
@@ -1013,7 +1013,10 @@
         "title": "AddEthereumChainParameter",
         "type": "object",
         "required": [
-          "chainId"
+          "chainId",
+          "chainName",
+          "rpcUrls",
+          "nativeCurrency"
         ],
         "properties": {
           "chainId": {


### PR DESCRIPTION
`wallet_addEthereumChain` requires `chainName`, `nativeCurrency` and `rpcUrls`. See that we enforce this [here](https://github.com/MetaMask/metamask-extension/blob/10996f0aaaf3a1d469cd79942c789e07152ad8f7/app/scripts/lib/rpc-method-middleware/handlers/add-ethereum-chain.js#L186). Currently the spec suggests that they are optional.