### PR TITLE
Add deprecation label to decryption methods

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -589,10 +589,13 @@
       "tags": [
         {
           "$ref": "#/components/tags/MetaMask"
+        },
+        {
+          "$ref": "#/components/tags/Deprecated"
         }
       ],
       "summary": "Decrypts an encrypted message.",
-      "description": "Requests that MetaMask decrypt the specified encrypted message. The message must have been encrypted using the public encryption key of the specified Ethereum address. Returns a promise that resolves to the decrypted message, or rejects if the decryption attempt fails.",
+      "description": "This method is deprecated and may be removed in the future. \n\n Requests that MetaMask decrypt the specified encrypted message. The message must have been encrypted using the public encryption key of the specified Ethereum address. Returns a promise that resolves to the decrypted message, or rejects if the decryption attempt fails.",
       "params": [
         {
           "name": "EncryptedMessage",
@@ -622,11 +625,14 @@
       "tags": [
         {
           "$ref": "#/components/tags/MetaMask"
+        },
+        {
+          "$ref": "#/components/tags/Deprecated"
         }
       ],
       "name": "eth_getEncryptionPublicKey",
       "summary": "Gets a public key used for encryption.",
-      "description": "Requests that the user share their public encryption key. Returns a public encryption key, or rejects if the user denies the request. The public key is computed from entropy associated with the specified user account, using the NaCl implementation of the `X25519_XSalsa20_Poly1305` algorithm.",
+      "description": "This method is deprecated and may be removed in the future. \n\n Requests that the user share their public encryption key. Returns a public encryption key, or rejects if the user denies the request. The public key is computed from entropy associated with the specified user account, using the NaCl implementation of the `X25519_XSalsa20_Poly1305` algorithm.",
       "params": [
         {
           "name": "Address",
@@ -1162,6 +1168,10 @@
       "Experimental": {
         "name": "Experimental",
         "description": "Experimental methods."
+      },
+      "Deprecated": {
+        "name": "Deprecated",
+        "description": "Deprecated methods."
       }
     },
     "errors": {


### PR DESCRIPTION
Add deprecation label and note to `eth_decrypt` and `eth_getEncryptionPublicKey`. Fixes https://github.com/MetaMask/metamask-docs/issues/1018.