### PR TITLE
Changed revokePermissions result type to be null

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -337,7 +337,7 @@
             }
           ],
           "result": {
-            "name": "UpdatedPermissionsAfterRevoke",
+            "name": "RevokePermissionsResult",
             "value": null
           }
         }

--- a/openrpc.json
+++ b/openrpc.json
@@ -319,10 +319,9 @@
         }
       ],
       "result": {
-        "name": "UpdatedPermissionsAfterRevoke",
-        "description": "The permissions list after the permission has been revoked",
+        "name": "RevokePermissionsResult",
         "schema": {
-          "$ref": "#/components/schemas/PermissionsList"
+          "type": "null"
         }
       },
       "errors": [],
@@ -339,7 +338,7 @@
           ],
           "result": {
             "name": "UpdatedPermissionsAfterRevoke",
-            "value": []
+            "value": null
           }
         }
       ]


### PR DESCRIPTION
This PR Changes `revokePermissions` to return null in all cases. Goes along with this PR in extension: https://github.com/MetaMask/metamask-extension/pull/22074

