### PR TITLE
Add info to `wallet_revokePermissions` description

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -307,8 +307,8 @@
           "$ref": "#/components/tags/Experimental"
         }
       ],
-      "summary": "Revoke the current dapp permissions.",
-      "description": "Revoke previously granted permissions for the current dapp identified by origin",
+      "summary": "Revokes the current dapp permissions.",
+      "description": "Revokes previously granted permissions for the current dapp identified by origin. This method is specified by [MIP-2](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-2.md) and is only available for the browser extension.",
       "params": [
         {
           "name": "revokePermissionObject",


### PR DESCRIPTION
Add reference to MIP-2 and note that the method is only available for the extension. See https://github.com/MetaMask/metamask-docs/issues/1020.