### PR TITLE
Adjust iconUrls param description

### DIFF
--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -1042,7 +1042,9 @@ components:
         iconUrls:
           description: >-
             (Optional) One or more URLs pointing to reasonably sized images that
-            can be used to visually identify the chain.
+            can be used to visually identify the chain. NOTE: MetaMask will not 
+            currently display these images. Values should still be included so 
+            that they are displayed once MetaMask displays custom iconUrls.
           type: array
           items:
             format: uri

--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -1043,8 +1043,9 @@ components:
           description: >-
             (Optional) One or more URLs pointing to reasonably sized images that
             can be used to visually identify the chain. NOTE: MetaMask will not 
-            currently display these images. Values should still be included so 
-            that they are displayed once MetaMask displays custom iconUrls.
+            currently display these images. Values can still be included so 
+            that they are utilized if MetaMask incorporates them into the display
+            of custom networks in the future.
           type: array
           items:
             format: uri


### PR DESCRIPTION
Specify the fact that MetaMask does not currently display the iconUrls supplied in `wallet_addEthereumChain`.