### PR TITLE
fix: personal_sign is 65 bytes long (not 129 bytes)

### DIFF
--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -247,7 +247,7 @@ methods:
           $ref: '#/components/schemas/address'
     result:
       name: Signature
-      description: A hex-encoded 129-byte array starting with `0x`.
+      description: A hex-encoded 65-byte array starting with `0x`.
       schema:
         $ref: '#/components/schemas/bytes'
     examples:


### PR DESCRIPTION
Fixes https://github.com/MetaMask/api-specs/issues/234