### PR TITLE
fix: filter unsupported methods

### DIFF
--- a/merge-openrpc.js
+++ b/merge-openrpc.js
@@ -48,7 +48,9 @@ const unneeded = [
   /eth_sign/,
   /debug_.*/,
   /engine_.*/,
-  /eth_createAccessList/
+  /eth_createAccessList/,
+  /eth_getBlockReceipts/,
+  /eth_maxPriorityFeePerGas/,
 ];
 
 const filterExecutionAPIs = (openrpcDocument) => {


### PR DESCRIPTION
see here for more info: https://github.com/MetaMask/metamask-extension/issues/24225

we can enable these again when that issue is resolved