### PR TITLE
Fix TypedData schema

### DIFF
--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -853,6 +853,13 @@ components:
           properties:
             EIP712Domain:
               type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
               description: >-
                 An array specifying one or more of the following domain
                 separator values: 1) `name` - The user-readable name of the signing


### PR DESCRIPTION
The `TypedData` parameter is throwing an error on the current reference:
<img width="539" alt="Screenshot 2024-08-21 at 1 33 16 PM" src="https://github.com/user-attachments/assets/fb42fa36-55e4-4a02-b37c-e880e6010ffa">

And the new reference:
<img width="924" alt="Screenshot 2024-08-21 at 1 33 41 PM" src="https://github.com/user-attachments/assets/aad60f2d-1f27-4838-82b8-346357254ed0">

This PR adds the required `items` property for the `EIP712Domain` array schema.