### PR TITLE
Filter out `eth_blobBaseFee`

### DIFF
--- a/merge-openrpc.js
+++ b/merge-openrpc.js
@@ -51,6 +51,7 @@ const unneeded = [
   /eth_createAccessList/,
   /eth_getBlockReceipts/,
   /eth_maxPriorityFeePerGas/,
+  /eth_blobBaseFee/,
 ];
 
 const filterExecutionAPIs = (openrpcDocument) => {


### PR DESCRIPTION
`eth_blobBaseFee` is not supported:

```json
{
  "code": -32601,
  "message": "The method \"eth_blobBaseFee\" does not exist / is not available.",
  "data": {
    "origin": "https://docs.metamask.io",
    "cause": null
  }
}
```