### PR TITLE
fix wallet create session unsupported scopes result example typo

### DIFF
--- a/multichain/openrpc.yaml
+++ b/multichain/openrpc.yaml
@@ -475,7 +475,7 @@ methods:
                   - eth_getBalance
                 notifications:
                   - eth_subscription
-      - result:
+        result:
           name: wallet_createSessionUnsupportedScopesResultExample
           value:
             sessionScopes:
@@ -567,7 +567,7 @@ methods:
                   - eth_subscription
           sessionProperties:
               expiry: "2022-11-31T17:07:31+00:00"
-            
+
     errors:
       - $ref: "#/components/errors/UnknownError"
       - code: 5100


### PR DESCRIPTION
There's a misformat that is causing the results property to end up in a separate item unintentionally