### PR TITLE
Revert "wallet_swapAsset v1"

### DIFF
--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -872,76 +872,6 @@ methods:
         result:
           name: eth_unsubscribeExampleResult
           value: true
-  - name: wallet_swapAsset
-    tags:
-      - $ref: '#/components/tags/MetaMask'
-      - $ref: '#/components/tags/Experimental'
-    summary: Allows dApps to request MetaMask to perform a token swap operation.
-    description: >-
-      This method enables dApps to initiate a token swap directly within MetaMask, improving the user experience by streamlining the process of swapping tokens. The method accepts parameters for the source and destination tokens and initiates a token swap operation.
-    params:
-      - name: SwapAssetParameter
-        required: true
-        schema:
-          title: SwapAssetParameter
-          type: object
-          required:
-            - fromToken
-            - toToken
-            - userAddress
-          properties:
-            fromToken:
-              type: array
-              items:
-                type: object
-                required:
-                  - address
-                properties:
-                  address:
-                    type: string
-                    description: The CAIP-10 formatted address of the source token.
-                    $ref: '#/components/schemas/Caip10Address'
-                  value:
-                    type: string
-                    description: (Optional) The amount of the source token to be swapped, in wei, as a hexadecimal string, defaults to 0.
-                    nullable: true
-            toToken:
-              type: object
-              required:
-                - address
-              properties:
-                address:
-                  type: string
-                  description: The CAIP-10 formatted address of the destination token.
-                  $ref: '#/components/schemas/Caip10Address'
-            userAddress:
-              type: string
-              description: The CAIP-10 formatted address of the user performing the swap.
-              $ref: '#/components/schemas/Caip10Address'
-    result:
-      name: SwapAssetResult
-      description: A boolean indicating if the swap was initiated successfully.
-      schema:
-        type: boolean
-    errors:
-      - code: 6000
-        message: "Swap is not available on this chain {{chainName}}"
-      - code: -32600
-        message: "Cross-chain swaps are currently not supported. Both fromToken and toToken must be on the same blockchain."
-    examples:
-      - name: wallet_swapAsset example
-        params:
-          - name: SwapAssetParameter
-            value:
-              from:
-                - tokenAddress: '0x1234567890abcdefABCDEF1234567890ABCDEF'
-                  value: '0xDE0B6B3A7640000'
-              to:
-                tokenAddress: '0xabcdef1234567890ABCDEF1234567890abcdef'
-              userAddress: '0x0000000000000000000000000000000000000000'
-        result:
-          name: wallet_swapAssetExampleResult
-          value: true
 components:
   schemas:
     TypedData:
@@ -1127,10 +1057,6 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Permission'
-    Caip10Address:
-      title: Caip10Address
-      type: string
-      description: CAIP-10 defines a way to identify an account/address in any blockchain.
   tags:
     MetaMask:
       name: MetaMask


### PR DESCRIPTION
Reverts MetaMask/api-specs#201 due to `wallet_swapAsset` not being live yet.