### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*  @MetaMask/wallet-api-platform-engineers
-*  @MetaMask/tech-writers
+*  @MetaMask/wallet-api-platform-engineers @MetaMask/tech-writers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/devs
+*  @MetaMask/wallet-api-platform-engineers
+*  @MetaMask/tech-writers


### PR DESCRIPTION
`@MetaMask/devs` is no longer a used org team. 

`@MetaMask/wallet-api-platform-engineers` and `@MetaMask/tech-writers` are the proper owners of this repo