### PR TITLE
Upgrade workflows to use ubuntu-latest

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-test:
     name: Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
@@ -23,7 +23,7 @@ jobs:
     - run: yarn test
   all-jobs-pass:
     name: All jobs pass
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - build-test
     steps:


### PR DESCRIPTION
The build-test workflow uses the Ubuntu 20.04 image, which GitHub deprecated some time ago. Because of this new PRs will no longer pass CI. This commit upgrades the workflow to ubuntu-latest which should always work (and matches what we do in other repos).