### PR TITLE
Add ERC-7715 execution permission methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add ERC-7715 execution permission methods: `wallet_requestExecutionPermissions`, `wallet_getGrantedExecutionPermissions`, `wallet_getSupportedExecutionPermissions`, `wallet_revokeExecutionPermission`, along with the `ExecutionPermission`, `ExecutionPermissionRule`, `ExecutionPermissionRequest`, and `ExecutionPermissionResponse` schemas ([#311](https://github.com/MetaMask/api-specs/pull/311))
+- Add ERC-7715 execution permission methods: `wallet_requestExecutionPermissions`, `wallet_getGrantedExecutionPermissions`, and `wallet_getSupportedExecutionPermissions`, along with the `ExecutionPermission`, `ExecutionPermissionRule`, `ExecutionPermissionRequest`, and `ExecutionPermissionResponse` schemas ([#311](https://github.com/MetaMask/api-specs/pull/311))
 
 ## [0.14.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add ERC-7715 execution permission methods: `wallet_requestExecutionPermissions`, `wallet_getGrantedExecutionPermissions`, `wallet_getSupportedExecutionPermissions`, `wallet_revokeExecutionPermission`, along with the `ExecutionPermission`, `ExecutionPermissionRule`, `ExecutionPermissionRequest`, and `ExecutionPermissionResponse` schemas ([#311](https://github.com/MetaMask/api-specs/pull/311))
 
 ## [0.14.0]
 ### Added

--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -828,7 +828,7 @@ methods:
                 rules:
                   - type: expiry
                     data:
-                      timestamp: 1739577600
+                      timestamp: 1893456000
         result:
           name: Granted permissions
           value:
@@ -844,7 +844,7 @@ methods:
               rules:
                 - type: expiry
                   data:
-                    timestamp: 1739577600
+                    timestamp: 1893456000
               context: '0x00000000000000000000000000000000000000000000000000000000000000'
               delegationManager: '0x2D48e6f5Ae053e4E918d2be53570961D880905F2'
               dependencies: []
@@ -1455,6 +1455,7 @@ components:
         - chainId
         - to
         - permission
+        - rules
       properties:
         chainId:
           description: >-
@@ -1477,7 +1478,8 @@ components:
           description: >-
             An array of rules constraining the permission. Time-bounded
             permissions are expressed as an `expiry` rule (with a UNIX
-            `timestamp` in its `data`) rather than a top-level field.
+            `timestamp` in its `data`) rather than a top-level field. Pass an
+            empty array to apply no constraints.
           type: array
           items:
             $ref: '#/components/schemas/ExecutionPermissionRule'

--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -781,6 +781,180 @@ methods:
             '0xaa36a7':
               atomic:
                 status: ready
+  - name: wallet_requestExecutionPermissions
+    tags:
+      - $ref: '#/components/tags/MetaMask'
+      - $ref: '#/components/tags/Experimental'
+      - $ref: '#/components/tags/Multichain'
+    summary: Requests ERC-7715 execution permissions.
+    description: >-
+      Requests that the user grant one or more ERC-7715 execution permissions,
+      allowing a delegate account to perform a constrained set of actions on
+      behalf of the user's account. Specified by
+      [ERC-7715](https://eips.ethereum.org/EIPS/eip-7715).
+    params:
+      - name: Permission requests
+        required: true
+        description: An array of execution permission requests.
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExecutionPermissionRequest'
+    result:
+      name: Granted permissions
+      description: An array of the granted execution permissions.
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ExecutionPermissionResponse'
+    errors:
+      - $ref: '#/components/errors/InvalidParams'
+      - $ref: '#/components/errors/UserRejected'
+      - $ref: '#/components/errors/Unauthorized'
+    examples:
+      - name: wallet_requestExecutionPermissions example
+        params:
+          - name: Permission requests
+            value:
+              - chainId: '0xaa36a7'
+                to: '0x4B0897b0513FdBeEc7C469D9aF4fA6C0752aBea7'
+                permission:
+                  type: native-token-periodic
+                  isAdjustmentAllowed: true
+                  data:
+                    periodAmount: '0x38d7ea4c68000'
+                    periodDuration: 86400
+                    justification: Permission to transfer 0.001 ETH every day
+                rules: []
+        result:
+          name: Granted permissions
+          value:
+            - chainId: '0xaa36a7'
+              to: '0x4B0897b0513FdBeEc7C469D9aF4fA6C0752aBea7'
+              permission:
+                type: native-token-periodic
+                isAdjustmentAllowed: true
+                data:
+                  periodAmount: '0x38d7ea4c68000'
+                  periodDuration: 86400
+                  justification: Permission to transfer 0.001 ETH every day
+              rules: []
+              context: '0x00000000000000000000000000000000000000000000000000000000000000'
+              delegationManager: '0x2D48e6f5Ae053e4E918d2be53570961D880905F2'
+              dependencies: []
+  - name: wallet_getGrantedExecutionPermissions
+    tags:
+      - $ref: '#/components/tags/MetaMask'
+      - $ref: '#/components/tags/Experimental'
+      - $ref: '#/components/tags/Multichain'
+    summary: Gets granted ERC-7715 execution permissions.
+    description: >-
+      Returns the ERC-7715 execution permissions that the user has previously
+      granted to the requesting dapp. Specified by
+      [ERC-7715](https://eips.ethereum.org/EIPS/eip-7715).
+    params: []
+    result:
+      name: Granted permissions
+      description: An array of the granted execution permissions.
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ExecutionPermissionResponse'
+    errors:
+      - $ref: '#/components/errors/Unauthorized'
+    examples:
+      - name: wallet_getGrantedExecutionPermissions example
+        params: []
+        result:
+          name: Granted permissions
+          value: []
+  - name: wallet_getSupportedExecutionPermissions
+    tags:
+      - $ref: '#/components/tags/MetaMask'
+      - $ref: '#/components/tags/Experimental'
+      - $ref: '#/components/tags/Multichain'
+    summary: Gets supported ERC-7715 execution permissions.
+    description: >-
+      Returns the ERC-7715 execution permission types supported by the wallet,
+      keyed by permission type, including the chain IDs and rule types each
+      permission supports. Specified by
+      [ERC-7715](https://eips.ethereum.org/EIPS/eip-7715).
+    params: []
+    result:
+      name: Supported permissions
+      description: >-
+        An object keyed by permission type. Each entry describes the chain IDs
+        and rule types supported for that permission type.
+      schema:
+        type: object
+        additionalProperties:
+          type: object
+          properties:
+            chainIds:
+              description: The chain IDs that support the permission type.
+              type: array
+              items:
+                $ref: '#/components/schemas/uint'
+            ruleTypes:
+              description: The rule types supported for the permission type.
+              type: array
+              items:
+                type: string
+    errors:
+      - $ref: '#/components/errors/Unauthorized'
+    examples:
+      - name: wallet_getSupportedExecutionPermissions example
+        params: []
+        result:
+          name: Supported permissions
+          value:
+            native-token-periodic:
+              chainIds:
+                - '0xaa36a7'
+              ruleTypes:
+                - expiry
+  - name: wallet_revokeExecutionPermission
+    tags:
+      - $ref: '#/components/tags/MetaMask'
+      - $ref: '#/components/tags/Experimental'
+      - $ref: '#/components/tags/Multichain'
+    summary: Revokes an ERC-7715 execution permission.
+    description: >-
+      Revokes a previously granted ERC-7715 execution permission, identified by
+      its permission context. Specified by
+      [ERC-7715](https://eips.ethereum.org/EIPS/eip-7715).
+    params:
+      - name: Revoke request
+        required: true
+        description: An object identifying the permission to revoke.
+        schema:
+          type: object
+          required:
+            - permissionContext
+          properties:
+            permissionContext:
+              description: >-
+                The `0x`-prefixed context of the permission to revoke, as
+                returned by `wallet_requestExecutionPermissions`.
+              $ref: '#/components/schemas/bytes'
+    result:
+      name: Null response
+      description: This method returns an empty object if the permission is revoked.
+      schema:
+        type: object
+        additionalProperties: false
+    errors:
+      - $ref: '#/components/errors/InvalidParams'
+      - $ref: '#/components/errors/Unauthorized'
+    examples:
+      - name: wallet_revokeExecutionPermission example
+        params:
+          - name: Revoke request
+            value:
+              permissionContext: '0x00000000000000000000000000000000000000000000000000000000000000'
+        result:
+          name: Null response
+          value: {}
   - name: eth_requestAccounts
     tags:
       - $ref: '#/components/tags/MetaMask'
@@ -1262,6 +1436,126 @@ components:
             Dapps can use this object to communicate with the wallet about
             supported capabilities.
           type: object
+    ExecutionPermission:
+      title: ExecutionPermission
+      description: >-
+        An ERC-7715 execution permission. The `type` determines the shape of the
+        `data` object (for example `native-token-periodic`, `native-token-stream`,
+        `erc20-token-periodic`, `erc20-token-allowance`).
+      type: object
+      required:
+        - type
+        - data
+      properties:
+        type:
+          description: The permission type.
+          type: string
+        isAdjustmentAllowed:
+          description: >-
+            Whether the wallet is allowed to adjust the requested permission
+            (for example to a lower allowance) before granting it.
+          type: boolean
+        data:
+          description: >-
+            Permission-type-specific data. All amounts are `0x`-prefixed
+            hexadecimal strings.
+          type: object
+          additionalProperties: true
+          properties:
+            justification:
+              description: A human-readable explanation of why the permission is requested.
+              type: string
+    ExecutionPermissionRule:
+      title: ExecutionPermissionRule
+      description: >-
+        A rule that constrains an ERC-7715 execution permission, such as an
+        `expiry`, `redeemer`, or `payee` rule.
+      type: object
+      required:
+        - type
+        - data
+      properties:
+        type:
+          description: The rule type.
+          type: string
+        data:
+          description: Rule-type-specific data.
+          type: object
+          additionalProperties: true
+    ExecutionPermissionRequest:
+      title: ExecutionPermissionRequest
+      description: An object describing a single ERC-7715 execution permission request.
+      type: object
+      required:
+        - chainId
+        - permission
+      properties:
+        chainId:
+          description: >-
+            The [EIP-155](https://eips.ethereum.org/EIPS/eip-155) chain ID the
+            permission applies to, as a `0x`-prefixed hexadecimal string.
+          $ref: '#/components/schemas/uint'
+        address:
+          description: >-
+            (Optional) The account address the permission should be granted from.
+          $ref: '#/components/schemas/address'
+        from:
+          description: >-
+            (Optional) The account address the permission should be granted from.
+          $ref: '#/components/schemas/address'
+        to:
+          description: The address the permission is granted to (the redeemer/delegate).
+          $ref: '#/components/schemas/address'
+        signer:
+          description: >-
+            (Optional) The signer that will redeem the permission. Used by the
+            ERC-7715 `account`/`wallet`/`key` signer types.
+          type: object
+          additionalProperties: true
+        expiry:
+          description: >-
+            (Optional) The UNIX timestamp (in seconds) after which the
+            permission is no longer valid.
+          type: number
+        permission:
+          $ref: '#/components/schemas/ExecutionPermission'
+        rules:
+          description: An array of rules constraining the permission.
+          type: array
+          items:
+            $ref: '#/components/schemas/ExecutionPermissionRule'
+    ExecutionPermissionResponse:
+      title: ExecutionPermissionResponse
+      description: >-
+        A granted ERC-7715 execution permission. Contains the original request
+        fields plus the data needed to redeem the permission.
+      allOf:
+        - $ref: '#/components/schemas/ExecutionPermissionRequest'
+        - type: object
+          properties:
+            context:
+              description: >-
+                An opaque `0x`-prefixed context used to identify and redeem the
+                granted permission.
+              $ref: '#/components/schemas/bytes'
+            delegationManager:
+              description: The address of the delegation manager contract.
+              $ref: '#/components/schemas/address'
+            dependencies:
+              description: >-
+                Account deployment dependencies required to redeem the
+                permission (for example a smart account factory and its data).
+              type: array
+              items:
+                title: ExecutionPermissionDependency
+                type: object
+                properties:
+                  factory:
+                    description: The address of the account factory contract.
+                    $ref: '#/components/schemas/address'
+                  factoryData:
+                    description: The calldata to pass to the account factory.
+                    $ref: '#/components/schemas/bytes'
     AddEthereumChainParameter:
       title: Chain
       description: Object containing information about the chain to add.

--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -825,7 +825,10 @@ methods:
                     periodAmount: '0x38d7ea4c68000'
                     periodDuration: 86400
                     justification: Permission to transfer 0.001 ETH every day
-                rules: []
+                rules:
+                  - type: expiry
+                    data:
+                      timestamp: 1739577600
         result:
           name: Granted permissions
           value:
@@ -838,7 +841,10 @@ methods:
                   periodAmount: '0x38d7ea4c68000'
                   periodDuration: 86400
                   justification: Permission to transfer 0.001 ETH every day
-              rules: []
+              rules:
+                - type: expiry
+                  data:
+                    timestamp: 1739577600
               context: '0x00000000000000000000000000000000000000000000000000000000000000'
               delegationManager: '0x2D48e6f5Ae053e4E918d2be53570961D880905F2'
               dependencies: []
@@ -913,48 +919,6 @@ methods:
                 - '0xaa36a7'
               ruleTypes:
                 - expiry
-  - name: wallet_revokeExecutionPermission
-    tags:
-      - $ref: '#/components/tags/MetaMask'
-      - $ref: '#/components/tags/Experimental'
-      - $ref: '#/components/tags/Multichain'
-    summary: Revokes an ERC-7715 execution permission.
-    description: >-
-      Revokes a previously granted ERC-7715 execution permission, identified by
-      its permission context. Specified by
-      [ERC-7715](https://eips.ethereum.org/EIPS/eip-7715).
-    params:
-      - name: Revoke request
-        required: true
-        description: An object identifying the permission to revoke.
-        schema:
-          type: object
-          required:
-            - permissionContext
-          properties:
-            permissionContext:
-              description: >-
-                The `0x`-prefixed context of the permission to revoke, as
-                returned by `wallet_requestExecutionPermissions`.
-              $ref: '#/components/schemas/bytes'
-    result:
-      name: Null response
-      description: This method returns an empty object if the permission is revoked.
-      schema:
-        type: object
-        additionalProperties: false
-    errors:
-      - $ref: '#/components/errors/InvalidParams'
-      - $ref: '#/components/errors/Unauthorized'
-    examples:
-      - name: wallet_revokeExecutionPermission example
-        params:
-          - name: Revoke request
-            value:
-              permissionContext: '0x00000000000000000000000000000000000000000000000000000000000000'
-        result:
-          name: Null response
-          value: {}
   - name: eth_requestAccounts
     tags:
       - $ref: '#/components/tags/MetaMask'
@@ -1445,6 +1409,7 @@ components:
       type: object
       required:
         - type
+        - isAdjustmentAllowed
         - data
       properties:
         type:
@@ -1488,6 +1453,7 @@ components:
       type: object
       required:
         - chainId
+        - to
         - permission
       properties:
         chainId:
@@ -1505,21 +1471,13 @@ components:
         to:
           description: The address the permission is granted to (the redeemer/delegate).
           $ref: '#/components/schemas/address'
-        signer:
-          description: >-
-            (Optional) The signer that will redeem the permission. Used by the
-            ERC-7715 `account`/`wallet`/`key` signer types.
-          type: object
-          additionalProperties: true
-        expiry:
-          description: >-
-            (Optional) The UNIX timestamp (in seconds) after which the
-            permission is no longer valid.
-          type: number
         permission:
           $ref: '#/components/schemas/ExecutionPermission'
         rules:
-          description: An array of rules constraining the permission.
+          description: >-
+            An array of rules constraining the permission. Time-bounded
+            permissions are expressed as an `expiry` rule (with a UNIX
+            `timestamp` in its `data`) rather than a top-level field.
           type: array
           items:
             $ref: '#/components/schemas/ExecutionPermissionRule'
@@ -1531,6 +1489,10 @@ components:
       allOf:
         - $ref: '#/components/schemas/ExecutionPermissionRequest'
         - type: object
+          required:
+            - context
+            - dependencies
+            - delegationManager
           properties:
             context:
               description: >-
@@ -1548,6 +1510,9 @@ components:
               items:
                 title: ExecutionPermissionDependency
                 type: object
+                required:
+                  - factory
+                  - factoryData
                 properties:
                   factory:
                     description: The address of the account factory contract.

--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -1495,13 +1495,12 @@ components:
             The [EIP-155](https://eips.ethereum.org/EIPS/eip-155) chain ID the
             permission applies to, as a `0x`-prefixed hexadecimal string.
           $ref: '#/components/schemas/uint'
-        address:
-          description: >-
-            (Optional) The account address the permission should be granted from.
-          $ref: '#/components/schemas/address'
         from:
           description: >-
-            (Optional) The account address the permission should be granted from.
+            (Optional) The account the permission should be granted from. Useful
+            when a connection has been established and multiple accounts have
+            been exposed; lets the user choose which account to grant the
+            permission for.
           $ref: '#/components/schemas/address'
         to:
           description: The address the permission is granted to (the redeemer/delegate).

--- a/openrpc.yaml
+++ b/openrpc.yaml
@@ -824,6 +824,7 @@ methods:
                   data:
                     periodAmount: '0x38d7ea4c68000'
                     periodDuration: 86400
+                    startTime: 1798761600
                     justification: Permission to transfer 0.001 ETH every day
                 rules:
                   - type: expiry
@@ -840,6 +841,7 @@ methods:
                 data:
                   periodAmount: '0x38d7ea4c68000'
                   periodDuration: 86400
+                  startTime: 1798761600
                   justification: Permission to transfer 0.001 ETH every day
               rules:
                 - type: expiry
@@ -1422,8 +1424,8 @@ components:
           type: boolean
         data:
           description: >-
-            Permission-type-specific data. All amounts are `0x`-prefixed
-            hexadecimal strings.
+            Permission-type-specific data. Token amounts are `0x`-prefixed
+            hexadecimal strings; timestamps and durations are numbers (seconds).
           type: object
           additionalProperties: true
           properties:


### PR DESCRIPTION
## Summary

Adds OpenRPC definitions for three ERC-7715 execution permission methods and their supporting schemas:

- `wallet_requestExecutionPermissions`
- `wallet_getGrantedExecutionPermissions`
- `wallet_getSupportedExecutionPermissions`

New `components/schemas`: `ExecutionPermission`, `ExecutionPermissionRule`, `ExecutionPermissionRequest`, `ExecutionPermissionResponse`.

> [!NOTE]
> `wallet_revokeExecutionPermission` is intentionally **not** included. While `@metamask/eth-json-rpc-middleware` defines a handler for it, the wallet does not currently wire it up — `createMetamaskMiddleware` passes only the request/getGranted/getSupported hooks (no `processRevokeExecutionPermission`), and neither `metamask-extension` nor `metamask-mobile` provides that hook. Documenting it here would make it authorizable over the Multichain API while actual calls throw `methodNotSupported` ("no middleware configured"). It will be added once the client wiring lands.

## Motivation

These methods are already implemented in the wallet (handled by the permissions kernel Snap) and work over the EIP-1193 provider (`window.ethereum`). However, they are **absent from the OpenRPC document**, which is the source of truth for `KnownRpcMethods.eip155` in [`@metamask/chain-agnostic-permission`](https://github.com/MetaMask/core/tree/main/packages/chain-agnostic-permission):

```ts
const Eip155Methods = MetaMaskOpenRPCDocument.methods
  .map(({ name }) => name)
  .filter(...) // WalletEip155Methods / KnownWalletRpcMethods / Eip1193OnlyMethods
```

Because the methods are not in this list, the Multichain API's `wallet_invokeMethod` handler rejects them:

```js
// @metamask/multichain-api-middleware wallet-invokeMethod
if (!scopeObject?.methods?.includes(wrappedRequest.method)) {
  return end(providerErrors.unauthorized());
}
```

So any dapp invoking ERC-7715 over the Multichain API (e.g. via **MetaMask Connect**, which routes all EVM requests through `wallet_invokeMethod`) fails with `UnauthorizedProviderError: The requested account and/or method has not been authorized by the user`, even though the same call succeeds over EIP-1193.

Adding these methods to the OpenRPC document makes them authorizable within an `eip155` CAIP-25 session scope. No additional wiring is required on the wallet side: once authorized, the request already flows through the shared `metamaskMiddleware` to the execution-permission handler.

## Schema notes

The request/response schemas mirror the wire contract in [`@metamask/7715-permission-types`](https://github.com/MetaMask/core) and the transform applied by `@metamask/smart-accounts-kit`:

- `ExecutionPermissionRequest` wire fields are `chainId`, `from` (optional), `to`, `permission`, and `rules`. There is no top-level `expiry`/`signer`/`address`; time bounds are expressed as an `expiry` **rule** (`{ type: 'expiry', data: { timestamp } }`), which is how the kit serializes a developer-supplied `expiry`.
- `isAdjustmentAllowed` (on `ExecutionPermission`) and `to` (on `ExecutionPermissionRequest`) are required.
- `ExecutionPermissionResponse` requires `context`, `dependencies`, and `delegationManager` (needed to redeem the permission); each dependency entry requires both `factory` and `factoryData`.

## Changes

- `openrpc.yaml`: 3 methods + 4 schemas (tagged `MetaMask` / `Experimental` / `Multichain`).
- `CHANGELOG.md`: `[Unreleased]` entry.

## Test plan

- [x] `yarn build` regenerates `dist/build/openrpc.json` without errors.
- [x] All three methods appear in the built `openrpc.json`.
- [x] `yarn test` passes (`parseOpenRPCDocument` validates the document and dereferences all `$ref`s, including the new schemas/tags/errors).
- [x] Verified the three methods are included in the derived `KnownRpcMethods.eip155` set after the filters applied by `@metamask/chain-agnostic-permission`.

## Downstream

After release, bump `@metamask/api-specs` in `@metamask/chain-agnostic-permission` (MetaMask/core), then bump `@metamask/chain-agnostic-permission` in `metamask-extension` and `metamask-mobile`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spec-only change, but it expands which delegate/execution permission RPCs are considered known and authorizable—downstream permission packages must pick up the release for Multichain routing to work.
> 
> **Overview**
> Documents **ERC-7715 execution permissions** in the OpenRPC spec so dapps can use them through the Multichain API (e.g. MetaMask Connect), not only via EIP-1193.
> 
> **`openrpc.yaml`** adds three methods (`wallet_requestExecutionPermissions`, `wallet_getGrantedExecutionPermissions`, `wallet_getSupportedExecutionPermissions`) with MetaMask / Experimental / Multichain tags, plus four schemas (`ExecutionPermission`, `ExecutionPermissionRule`, `ExecutionPermissionRequest`, `ExecutionPermissionResponse`) aligned with the existing wire contract (rules-based expiry, redemption fields like `context` and `delegationManager`). **`CHANGELOG.md`** records the addition under `[Unreleased]`.
> 
> `wallet_revokeExecutionPermission` is intentionally omitted until clients wire it up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d131dc5c8b526829cec3f2524801400de2261a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

