### PR TITLE
chore: update release docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,26 +3,15 @@ Creating a new release:
 
 This repository uses [Github Actions](https://docs.github.com/en/actions) to release.
 
-1. Start on the `main` branch and on latest
-    ```
-      git checkout main
-      git pull origin main
-    ```
-1. Create a branch with the correct name: `release-v${version}`
+1. Go to the [Create Release Pull Request](https://github.com/MetaMask/api-specs/actions/workflows/create-release-pr.yml) workflow on GitHub Actions and click **Run workflow**.
 
-    ex:
-    ```
-      git checkout -b release-v0.0.1
-    ```
+1. Fill in the inputs:
+    - **base-branch**: `main` (default)
+    - **release-type**: a SemVer bump type — `major`, `minor`, or `patch` (mutually exclusive with `release-version`)
+    - **release-version**: a specific version to bump to, e.g. `0.15.0` (mutually exclusive with `release-type`)
 
-1. Push the branch to origin
+1. The workflow will open a Pull Request with version bumps and changelog updates.
 
-    ```
-      git push origin release-v0.0.1
-    ```
+1. Review the pull request and merge when ready.
 
-1. kicks off [.github/workflows/release-pr.yml](/.github/workflows/release-pr.yml)
-1. A [Pull Request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) should be created
-1. Review pull request
-1. Merge PR when ready to release
-1. Release kicks off and runs [.github/workflows/release-merge.yml](/.github/workflows/release-merge.yml)
+1. Merging into `main` triggers [.github/workflows/publish-release.yml](/.github/workflows/publish-release.yml), which publishes the package to npm and deploys docs to GitHub Pages.


### PR DESCRIPTION
Updates `RELEASING.md` with accurate instructions on how to release this package. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or release automation behavior modified.
> 
> **Overview**
> **Replaces manual git release steps** in `RELEASING.md` with a **GitHub Actions–driven flow**: run the **Create Release Pull Request** workflow (`create-release-pr.yml`), set **base-branch** / **release-type** or **release-version**, then review and merge the auto-opened PR.
> 
> **Updates post-merge behavior** to point at **`publish-release.yml`** (npm publish + GitHub Pages docs) instead of the old **`release-pr.yml`** / **`release-merge.yml`** references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e2fc26a09484e2464f98defc8479d3ae38f967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->