### PR TITLE
docs: link to the Multichain API prose reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ You can view the specs in the following formats:
 human-readable, and machine-readable.
 It improves the accuracy of documentation, APIs, and clients.
 
+> **Multichain API (CAIP-25 / CAIP-27).** For a prose walkthrough of the
+> Multichain API — `wallet_createSession` inputs/outputs, supported methods, error
+> codes, and how MetaMask currently diverges from the latest CAIP-25 — see
+> [`MULTICHAIN_API.md`](https://github.com/MetaMask/core/blob/main/packages/multichain-api-middleware/MULTICHAIN_API.md)
+> in `@metamask/multichain-api-middleware`. The `multichain/openrpc.yaml` file here
+> is the machine-readable source of truth for that API.
+
 ## Contribute
 
 You can contribute to the API specs using the following steps.


### PR DESCRIPTION
## Summary

Adds a callout in the README pointing readers to the new wallet-side [Multichain API reference](https://github.com/MetaMask/core/blob/main/packages/multichain-api-middleware/MULTICHAIN_API.md) in `@metamask/multichain-api-middleware`, and clarifies that `multichain/openrpc.yaml` here is the machine-readable source of truth for that API.

The OpenRPC spec is accurate but not easy to read end-to-end; the new doc gives a prose walkthrough (inputs/outputs, supported methods, error codes, and divergences from the current CAIP-25). This just cross-links the two.

Depends on the companion `MetaMask/core` PR that adds `MULTICHAIN_API.md` (link targets `main`).

## Test plan

- [x] Markdown renders; link resolves once the `core` doc merges to `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or spec file edits.
> 
> **Overview**
> Adds a **Multichain API (CAIP-25 / CAIP-27)** callout to the README after the OpenRPC intro. It points readers to the prose [`MULTICHAIN_API.md`](https://github.com/MetaMask/core/blob/main/packages/multichain-api-middleware/MULTICHAIN_API.md) in `@metamask/multichain-api-middleware` for session setup, methods, errors, and CAIP-25 divergences, and states that **`multichain/openrpc.yaml`** in this repo remains the machine-readable source of truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a892daab47b8a5ad57378eec28be21faec03e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->